### PR TITLE
Removes slashes in data_files to prevent Windows install failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,8 @@ setup(
     packages=find_packages(),
     install_requires=install_requires,
     include_package_data=True,
-    data_files=[('htrc/mock/volumes/', ['htrc/mock/volumes/example.zip']),
-                ('htrc/', ['htrc/.htrc.default'])],
+    data_files=[('htrc/mock/volumes', ['htrc/mock/volumes/example.zip']),
+                ('htrc', ['htrc/.htrc.default'])],
     zip_safe=False,
     entry_points={
         'console_scripts': ['htrc = htrc.__main__:main']


### PR DESCRIPTION
This should present pip install failure in Windows with Anaconda, as per issue #19